### PR TITLE
Fix edition_imprint mapper.

### DIFF
--- a/lib/rdf2marc/rdf2model/mappers/edition_imprint_fields.rb
+++ b/lib/rdf2marc/rdf2model/mappers/edition_imprint_fields.rb
@@ -51,7 +51,7 @@ module Rdf2marc
         end
 
         def publication_distributions_names(subject_term)
-          item.instance.query.path_all_uri([[BF.agent, BF.Agent], BF.Agent],
+          item.instance.query.path_all([[BF.agent, BF.Agent], BF.Agent],
                                            subject_term: subject_term).map do |agent_term|
             agent_term.is_a?(RDF::Literal) ? agent_term.value : Resolver.resolve_label(agent_term&.value)
           end


### PR DESCRIPTION
To verify fix, `exe/rdf2marc https://api.development.sinopia.io/resource/4bf07817-38a4-41d5-8498-8a9a36b88ec4`. If completes without error, then success.