### PR TITLE
Fixes for corporate records.

### DIFF
--- a/lib/rdf2marc/model2marc/field_110.rb
+++ b/lib/rdf2marc/model2marc/field_110.rb
@@ -11,9 +11,9 @@ module Rdf2marc
       def build
         field.indicator1 = name_type
         append('a', model.corporate_name)
-        append('b', model.subordinate_unit)
-        append_repeatable('c', model.meeting_location)
-        append('d', model.meeting_date)
+        append_repeatable('b', model.subordinate_units)
+        append_repeatable('c', model.meeting_locations)
+        append_repeatable('d', model.meeting_dates)
         append_repeatable('e', model.relator_terms)
         append('f', model.work_date)
         append_repeatable('g', model.misc_infos)

--- a/lib/rdf2marc/model2marc/field_610.rb
+++ b/lib/rdf2marc/model2marc/field_610.rb
@@ -11,9 +11,9 @@ module Rdf2marc
       def build
         field.indicator1 = name_type
         append('a', model.corporate_name)
-        append('b', model.subordinate_unit)
-        append_repeatable('c', model.meeting_location)
-        append('d', model.meeting_date)
+        append_repeatable('b', model.subordinate_units)
+        append_repeatable('c', model.meeting_locations)
+        append_repeatable('d', model.meeting_dates)
         append_repeatable('e', model.relator_terms)
         append('f', model.work_date)
         append_repeatable('g', model.misc_infos)

--- a/lib/rdf2marc/model2marc/field_710.rb
+++ b/lib/rdf2marc/model2marc/field_710.rb
@@ -11,9 +11,9 @@ module Rdf2marc
       def build
         field.indicator1 = name_type
         append('a', model.corporate_name)
-        append('b', model.subordinate_unit)
-        append_repeatable('c', model.meeting_location)
-        append('d', model.meeting_date)
+        append_repeatable('b', model.subordinate_units)
+        append_repeatable('c', model.meeting_locations)
+        append_repeatable('d', model.meeting_dates)
         append_repeatable('e', model.relator_terms)
         append('f', model.work_date)
         append_repeatable('g', model.misc_infos)

--- a/lib/rdf2marc/models/general/corporate_name.rb
+++ b/lib/rdf2marc/models/general/corporate_name.rb
@@ -7,9 +7,9 @@ module Rdf2marc
       class CorporateName < Struct
         attribute :type, Types::String.default('direct').enum('inverted', 'jurisdiction', 'direct')
         attribute? :corporate_name, Types::String
-        attribute? :subordinate_unit, Types::Array.of(Types::String)
-        attribute? :meeting_location, Types::Array.of(Types::String)
-        attribute? :meeting_date, Types::Array.of(Types::String)
+        attribute? :subordinate_units, Types::Array.of(Types::String)
+        attribute? :meeting_locations, Types::Array.of(Types::String)
+        attribute? :meeting_dates, Types::Array.of(Types::String)
         attribute? :relator_terms, Types::Array.of(Types::String)
         attribute? :work_date, Types::String
         attribute? :misc_infos, Types::Array.of(Types::String)

--- a/lib/rdf2marc/resolver/id_loc_gov_resolver.rb
+++ b/lib/rdf2marc/resolver/id_loc_gov_resolver.rb
@@ -51,9 +51,9 @@ module Rdf2marc
         {
           type: name_type_for(field.indicator1),
           corporate_name: subfield_value(field, 'a', clean: true),
-          subordinate_unit: field['b'],
-          meeting_location: subfield_values(field, 'c'),
-          meeting_date: field['d'],
+          subordinate_units: subfield_values(field, 'b'),
+          meeting_locations: subfield_values(field, 'c'),
+          meeting_dates: subfield_values(field, 'd'),
           relator_terms: subfield_values(field, 'e'),
           work_date: field['f'],
           misc_infos: subfield_values(field, 'g'),


### PR DESCRIPTION
closes #14

```
$ exe/rdf2marc https://api.stage.sinopia.io/resource/877ffc5b-988e-45f6-888e-4ae0a6d75e69
W, [2020-10-07T12:58:00.674871 #73951]  WARN -- : Resolving type for http://id.nlm.nih.gov/mesh/D002665 not supported.
W, [2020-10-07T12:58:00.674935 #73951]  WARN -- : Resolving type for http://id.nlm.nih.gov/mesh/D005858 not supported.
W, [2020-10-07T12:58:00.674949 #73951]  WARN -- : Resolving type for http://id.nlm.nih.gov/mesh/D006778 not supported.
W, [2020-10-07T12:58:00.687230 #73951]  WARN -- : Resolving type for http://id.nlm.nih.gov/mesh/D049673 not supported.
W, [2020-10-07T12:58:00.687271 #73951]  WARN -- : Resolving type for http://id.nlm.nih.gov/mesh/D000296 not supported.
LEADER      nam a22     7u 4500
003 aeainml
008 201007|||||||||gx                  ger||
010    $a 2019377297 
020    $a 9783847108313 $q (hardbound ; alk. paper) 
040    $a aeainml $b eng $c aeainml $e rda 
100 1  $a Remschmidt, Helmut $0 http://id.loc.gov/authorities/names/n84189437 
245 10 $a Kontinuität und Innovation $b die Geschichte der Kinder- und Jugendpsychiatrie an der Philipps-Universität Marburg $c Helmut Remschmidt 
246 0  $a Geschichte der Kinder- und Jugendpsychiatrie an der Philipps-Universität Marburg 
264 1  $a Göttingen (Germany) $b V&R Unipress $c 2018 
300    $a 815 pages 
336    $a text $c txt $0 http://id.loc.gov/vocabulary/contentTypes/txt $2 rdacontent 
337    $a unmediated $c n $0 http://id.loc.gov/vocabulary/mediaTypes/n $2 rdamedia 
338    $a volume $c nc $0 http://id.loc.gov/vocabulary/carriers/nc $2 rdacarrier 
610 2  $a Philipps-Universität Marburg. $b Klinik für Kinder- und Jugendpsychiatrie $0 http://id.loc.gov/authorities/names/n2019016508 
884    $a Sinopia rdf2marc $g 20201007 $k https://api.stage.sinopia.io/resource/877ffc5b-988e-45f6-888e-4ae0a6d75e69 $u https://github.com/LD4P/rdf2marc 
```