### PR TITLE
Warn, but not error on literal subjects.

### DIFF
--- a/lib/rdf2marc/rdf2model/mappers/subject_access_fields.rb
+++ b/lib/rdf2marc/rdf2model/mappers/subject_access_fields.rb
@@ -14,8 +14,14 @@ module Rdf2marc
             geographic_names: [],
             genre_forms: genre_forms
           }
-          subject_uris = item.work.query.path_all_uri([BF.subject])
-          subject_uris.each do |subject_uri|
+          subject_terms = item.work.query.path_all([BF.subject])
+          subject_terms.each do |subject_term|
+            if subject_term.is_a?(RDF::Literal)
+              Logger.warn("Ignoring subject #{subject_term.value} since it is a literam.")
+              next
+            end
+
+            subject_uri = subject_term.value
             subject_type = Resolver.resolve_type(subject_uri)
             if subject_type == 'corporate_name'
               subj_fields[:corporate_names] << Resolver.resolve_model(subject_uri,


### PR DESCRIPTION
Before:
```
$ exe/rdf2marc https://api.stage.sinopia.io/resource/87b800a6-1090-4f81-9aa0-938994899f4e
Traceback (most recent call last):
	9: from exe/rdf2marc:16:in `<main>'
	8: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/converter.rb:15:in `convert'
	7: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/rdf2model.rb:12:in `to_model'
	6: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/rdf2model/mapper.rb:18:in `generate'
	5: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/rdf2model/mappers/subject_access_fields.rb:17:in `generate'
	4: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/graph_query.rb:43:in `path_all_uri'
	3: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/graph_query.rb:101:in `to_uris'
	2: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/graph_query.rb:101:in `map'
	1: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/graph_query.rb:101:in `block in to_uris'
/Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/graph_query.rb:91:in `to_uri': Not a URI: Nature--Effect of human beings on--Interactive multimedia (Rdf2marc::MappingError)
```

After:
```
$ exe/rdf2marc https://api.stage.sinopia.io/resource/87b800a6-1090-4f81-9aa0-938994899f4e
W, [2020-10-08T17:49:19.772327 #38998]  WARN -- : Ignoring subject Ecology--Interactive multimedia since it is a literam.
W, [2020-10-08T17:49:19.772418 #38998]  WARN -- : Ignoring subject  Feral animals--Interactive multimedia since it is a literam.
W, [2020-10-08T17:49:19.772451 #38998]  WARN -- : Ignoring subject Nature--Effect of human beings on--Interactive multimedia since it is a literam.
W, [2020-10-08T17:49:19.772465 #38998]  WARN -- : Ignoring subject Introduced organisms--Interactive multimedia since it is a literam.
LEADER      nam a22      u 4500
003 cst
008 201008|||||||||us                  eng||
020    $a 9781503615045 
040    $a cst $b eng $c cst $e rda 
050  0 $a GF75 $b .F47 2020 
245 10 $a Feral atlas $b the more-than-human Anthropocene $c curated and edited by Anna L. Tsing, Jennifer Deger, Alder Keleman Saxena and Feifei Zhou 
264 1  $a Stanford (Calif.) $b Stanford University Press $c 2020 
300    $a 1 online resource 
336    $a two-dimensional moving image $c tdi $0 http://id.loc.gov/vocabulary/contentTypes/tdi $2 rdacontent 
336    $a text $c txt $0 http://id.loc.gov/vocabulary/contentTypes/txt $2 rdacontent 
336    $a still image $c sti $0 http://id.loc.gov/vocabulary/contentTypes/sti $2 rdacontent 
337    $a computer $c c $0 http://id.loc.gov/vocabulary/mediaTypes/c $2 rdamedia 
338    $a online resource $c cr $0 http://id.loc.gov/vocabulary/carriers/cr $2 rdacarrier 
500    $a Description based on online resource (Stanford University Press, viewed October 6, 2020) 
655  7 $a Informational works $2 lcgft 
700 1  $a Deger, Jennifer $0 http://id.loc.gov/authorities/names/n2006049702 
700 1  $a Zhou, Feifei $0 http://id.loc.gov/authorities/names/no2020116578 
700 1  $a Tsing, Anna Lowenhaupt $0 http://id.loc.gov/authorities/names/n88647642 
700 1  $a Saxena, Alder Keleman $0 http://id.loc.gov/authorities/names/no2020116570 
884    $a Sinopia rdf2marc $g 20201008 $k https://api.stage.sinopia.io/resource/87b800a6-1090-4f81-9aa0-938994899f4e $u https://github.com/LD4P/rdf2marc 
```
