### PR TITLE
Handle missing 043 when resolving GAC.

### DIFF
--- a/lib/rdf2marc/rdf2model/mappers/subject_access_fields.rb
+++ b/lib/rdf2marc/rdf2model/mappers/subject_access_fields.rb
@@ -17,7 +17,7 @@ module Rdf2marc
           subject_terms = item.work.query.path_all([BF.subject])
           subject_terms.each do |subject_term|
             if subject_term.is_a?(RDF::Literal)
-              Logger.warn("Ignoring subject #{subject_term.value} since it is a literam.")
+              Logger.warn("Ignoring subject #{subject_term.value} since it is a literal.")
               next
             end
 

--- a/lib/rdf2marc/resolver/id_loc_gov_resolver.rb
+++ b/lib/rdf2marc/resolver/id_loc_gov_resolver.rb
@@ -150,6 +150,12 @@ module Rdf2marc
       def resolve_gac(uri)
         expect_type(uri, ['geographic_name'])
         marc_record = get_marc(uri)
+
+        if marc_record['043'].nil?
+          Logger.warn("Could not get GAC for #{uri} since missing field 043.")
+          return nil
+        end
+
         marc_record['043']['a']
       end
 


### PR DESCRIPTION
refs https://github.com/LD4P/sinopia_editor/issues/2648

Before:
```
$ exe/rdf2marc  https://api.stage.sinopia.io/resource/ed7fe5c4-2ac3-4cea-a136-32f2684ef375
Traceback (most recent call last):
	9: from exe/rdf2marc:16:in `<main>'
	8: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/converter.rb:15:in `convert'
	7: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/rdf2model.rb:12:in `to_model'
	6: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/rdf2model/mapper.rb:11:in `generate'
	5: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/rdf2model/mappers/number_and_code_fields.rb:13:in `generate'
	4: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/rdf2model/mappers/number_and_code_fields.rb:104:in `geographic_area_codes'
	3: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/rdf2model/mappers/number_and_code_fields.rb:104:in `map'
	2: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/rdf2model/mappers/number_and_code_fields.rb:105:in `block in geographic_area_codes'
	1: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/resolver.rb:50:in `resolve_geographic_area_code'
/Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/resolver/id_loc_gov_resolver.rb:153:in `resolve_gac': undefined method `[]' for nil:NilClass (NoMethodError)
```

After:
```
$ exe/rdf2marc  https://api.stage.sinopia.io/resource/ed7fe5c4-2ac3-4cea-a136-32f2684ef375
W, [2020-10-09T08:38:22.390300 #56534]  WARN -- : Could not get GAC for http://id.loc.gov/authorities/subjects/sh85074879 since missing field 043.
W, [2020-10-09T08:38:24.659735 #56534]  WARN -- : Ignoring subject Sexual minorities--Violence against--Latin America since it is a literal.
W, [2020-10-09T08:38:24.659779 #56534]  WARN -- : Ignoring subject Homophobia in schools--Latin America since it is a literal.
W, [2020-10-09T08:38:24.659793 #56534]  WARN -- : Ignoring subject Transphobia in schools--Latin America since it is a literal.
LEADER      nam a22      u 4500
003 cst
008 201009|||||||||cl                  spa||
040    $a cst $b eng $c cst $e rda 
050  0 $a HQ76.45.L29 
245 10 $a Violencia homofóbica y transfóbica en el ámbito escolar $b hacia centros educativos inclusivos y seguros en América Latina 
264 1  $a Santiago (Chile) $b Unesco. Regional Office for Education in Latin America and the Caribbean $c 2015 
300    $a 1 online resource (97 pages) 
336    $a text $c txt $0 http://id.loc.gov/vocabulary/contentTypes/txt $2 rdacontent 
337    $a computer $c c $0 http://id.loc.gov/vocabulary/mediaTypes/c $2 rdamedia 
338    $a online resource $c cr $0 http://id.loc.gov/vocabulary/carriers/cr $2 rdacarrier 
500    $a Description based on online resource (Internet Archive Wayback Machine, viewed August 10, 2020) 
655  7 $a Informational works $2 lcgft 
710 2  $a Unesco. $b Regional Office for Education in Latin America and the Caribbean $0 http://id.loc.gov/authorities/names/n50077214 
884    $a Sinopia rdf2marc $g 20201009 $k https://api.stage.sinopia.io/resource/ed7fe5c4-2ac3-4cea-a136-32f2684ef375 $u https://github.com/LD4P/rdf2marc 
```
```