### PR TITLE
The first indicator on 245 is 0 when there are no 1xx fields

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,7 +37,9 @@ Metrics/PerceivedComplexity:
 RSpec/FilePath:
   Exclude:
     - 'spec/rdf2marc/model2marc/*field_*_spec.rb'
-
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+  
 Security/Eval:
   Exclude:
     - 'lib/rdf2marc/model2marc/field.rb'

--- a/lib/rdf2marc/rdf2model/mapper.rb
+++ b/lib/rdf2marc/rdf2model/mapper.rb
@@ -5,12 +5,14 @@ module Rdf2marc
     # Maps RDF to model parameters.
     class Mapper < BaseMapper
       def generate
+        main_entry = Mappers::MainEntryFields.new(item).generate
+        has_100_field = main_entry.compact.keys.present?
         {
           leader: Mappers::Leader.new(item).generate,
           control_fields: Mappers::ControlFields.new(item).generate,
           number_and_code_fields: Mappers::NumberAndCodeFields.new(item).generate,
-          main_entry_fields: Mappers::MainEntryFields.new(item).generate,
-          title_fields: Mappers::TitleFields.new(item).generate,
+          main_entry_fields: main_entry,
+          title_fields: Mappers::TitleFields.new(item, has_100_field: has_100_field).generate,
           physical_description_fields: Mappers::PhysicalDescriptionFields.new(item).generate,
           series_statement_fields: Mappers::SeriesStatementFields.new(item).generate,
           note_fields: Mappers::NoteFields.new(item).generate,

--- a/lib/rdf2marc/rdf2model/mappers/title_fields.rb
+++ b/lib/rdf2marc/rdf2model/mappers/title_fields.rb
@@ -5,10 +5,15 @@ module Rdf2marc
     module Mappers
       # Mapping to Title Fields model.
       class TitleFields < BaseMapper
+        def initialize(item_context, has_100_field:)
+          super(item_context)
+          @has_100_field = has_100_field
+        end
+
         def generate
           {
             translated_titles: translated_titles,
-            title_statement: title_statement,
+            title_statement: title_statement(@has_100_field),
             variant_titles: variant_titles,
             former_titles: former_titles
           }
@@ -32,12 +37,13 @@ module Rdf2marc
           end
         end
 
-        def title_statement
+        def title_statement(has_100_field)
           # Record may contain multiple bf:Title. Only using one and which is selected is indeterminate.
           title_term = item.instance.query.path_first([[BF.title, BF.Title]])
           return nil if title_term.nil?
 
           {
+            added_entry: has_100_field ? 'added' : 'no_added',
             title: item.instance.query.path_first_literal([BF.mainTitle], subject_term: title_term),
             remainder_of_title: item.instance.query.path_first_literal([BF.subtitle], subject_term: title_term),
             # May be multiple bf.responsibilityStatement, but only using one.

--- a/spec/rdf2marc/rdf2model/mappers/mappers_shared_examples.rb
+++ b/spec/rdf2marc/rdf2model/mappers/mappers_shared_examples.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.shared_examples 'mapper' do |mapper_class|
   let(:subject) { mapper_class.new(context) }
 
@@ -26,4 +25,3 @@ RSpec.shared_examples 'mapper' do |mapper_class|
     expect(subject.generate.deep_compact).to eq model
   end
 end
-# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/rdf2marc/rdf2model/mappers/title_fields_spec.rb
+++ b/spec/rdf2marc/rdf2model/mappers/title_fields_spec.rb
@@ -3,6 +3,20 @@
 require 'rdf2marc/rdf2model/mappers/mappers_shared_examples'
 
 RSpec.describe Rdf2marc::Rdf2model::Mappers::TitleFields do
+  subject { mapper.generate.deep_compact }
+
+  let(:item_context) do
+    Rdf2marc::Rdf2model.item_context_for(graph, RDF::URI(instance_term), RDF::URI(work_term),
+                                         RDF::URI(admin_metadata_term))
+  end
+  let(:graph) { RDF::Graph.new.from_ttl(ttl) }
+
+  let(:instance_term) { 'https://api.sinopia.io/resource/test_instance' }
+  let(:work_term) { 'https://api.sinopia.io/resource/test_work' }
+  let(:admin_metadata_term) { 'https://api.sinopia.io/resource/test_admin_metadata' }
+
+  let(:mapper) { described_class.new(item_context, has_100_field: true) }
+
   context 'with minimal graph' do
     let(:ttl) { '' }
 
@@ -10,7 +24,7 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::TitleFields do
       {}
     end
 
-    include_examples 'mapper', described_class
+    it { is_expected.to eq model }
   end
 
   describe 'translated titles' do
@@ -35,7 +49,7 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::TitleFields do
       }
     end
 
-    include_examples 'mapper', described_class
+    it { is_expected.to eq model }
   end
 
   describe 'title statement' do
@@ -56,18 +70,39 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::TitleFields do
       TTL
     end
 
-    let(:model) do
-      {
-        title_statement: {
-          part_names: ['Student handbook', 'Supplement'],
-          part_numbers: ['Part B', 'Part one'],
-          remainder_of_title: 'orders, suborders, and great groups : National Soil Survey Classification of 1967',
-          title: 'Distribution of the principal kinds of soil'
+    context 'with a 1XX field' do
+      let(:model) do
+        {
+          title_statement: {
+            added_entry: 'added',
+            part_names: ['Student handbook', 'Supplement'],
+            part_numbers: ['Part B', 'Part one'],
+            remainder_of_title: 'orders, suborders, and great groups : National Soil Survey Classification of 1967',
+            title: 'Distribution of the principal kinds of soil'
+          }
         }
-      }
+      end
+
+      it { is_expected.to eq model }
     end
 
-    include_examples 'mapper', described_class
+    context 'without a 1XX field' do
+      let(:mapper) { described_class.new(item_context, has_100_field: false) }
+
+      let(:model) do
+        {
+          title_statement: {
+            added_entry: 'no_added',
+            part_names: ['Student handbook', 'Supplement'],
+            part_numbers: ['Part B', 'Part one'],
+            remainder_of_title: 'orders, suborders, and great groups : National Soil Survey Classification of 1967',
+            title: 'Distribution of the principal kinds of soil'
+          }
+        }
+      end
+
+      it { is_expected.to eq model }
+    end
   end
 
   describe 'variant titles' do
@@ -104,7 +139,7 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::TitleFields do
       }
     end
 
-    include_examples 'mapper', described_class
+    it { is_expected.to eq model }
   end
 
   describe 'former titles' do
@@ -129,6 +164,6 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::TitleFields do
       }
     end
 
-    include_examples 'mapper', described_class
+    it { is_expected.to eq model }
   end
 end


### PR DESCRIPTION

## Why was this change made?
Per https://www.loc.gov/marc/bibliographic/bd245.html

Fixes #35



## How was this change tested?



## Which documentation and/or configurations were updated?



