### PR TITLE
Switch to using marshal serizer for the cache

### DIFF
--- a/lib/rdf2marc.rb
+++ b/lib/rdf2marc.rb
@@ -113,7 +113,7 @@ module Rdf2marc
 
   def self.caching_http_adapter
     @caching_http_adapter ||= Faraday.new do |builder|
-      builder.use :http_cache, store: cache
+      builder.use :http_cache, store: cache, serializer: Marshal
       builder.use FaradayMiddleware::FollowRedirects
       builder.response :encoding # use Faraday::Encoding middleware
       builder.adapter Faraday.default_adapter


### PR DESCRIPTION
Fixes #99

## Why was this change made?
The default JSON serializer is known to have problems with UTF-8 characters per the faraday-http-cache README.


## How was this change tested?



## Which documentation and/or configurations were updated?



