### PR TITLE
Add a Dockerfile for the application so that it can be run as an ECS …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ruby:2.7.2
+
+WORKDIR /app
+# # Operating system dependencies
+RUN apt update && \
+  apt install -y build-essential
+
+# Application dependencies
+COPY . /app
+
+RUN bundle install --without development test

--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ Note when using Instance uri:
 * The Instance must contain a `bf:instanceOf` that references the Work or nests the Work via a blank node.
 * The Instance must contain a `bf:adminMetadata` that references the Admin Metadata or nests the Admin Metadata via a blank node.
 
+## Usage (Docker)
+
+Build the docker image:
+```
+docker build . -f Dockerfile -t ld4p/rdf2marc:latest
+```
+
+Run the above commands using the docker image:
+```
+docker run ld4p/rdf2marc <instance uri>
+```
+
 ## Caching
 Resolving external resources is slow. To speed this up, responses can be cached. The following caches are supported.
 * `Rdf2marc::Caches::NullCache`: No caching (the default).


### PR DESCRIPTION
…task

## Why was this change made?

This is a simple dockerization of this application so that it can be run within our ECS Cluster as a task when triggered from Airflow.

## How was this change tested?

Manually verified the image works and runs the executable properly.

## Which documentation and/or configurations were updated?

README

