### PR TITLE
main and added entry specs: remove extra whitespace in ttl

### DIFF
--- a/spec/rdf2marc/rdf2model/mappers/added_entry_fields_spec.rb
+++ b/spec/rdf2marc/rdf2model/mappers/added_entry_fields_spec.rb
@@ -304,10 +304,10 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::AddedEntryFields, :vcr do
       let(:ttl) do
         <<~TTL
           <#{work_term}> <http://id.loc.gov/ontologies/bibframe/contribution> _:b9.
-           _:b9 a <http://id.loc.gov/ontologies/bibframe/Contribution>;
-               <http://id.loc.gov/ontologies/bibframe/agent> _:b10.
-           _:b10 a <http://id.loc.gov/ontologies/bibframe/Organization>;
-               <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> "Iranian Chemical Society", "United States. Army Map Service".
+          _:b9 a <http://id.loc.gov/ontologies/bibframe/Contribution>;
+              <http://id.loc.gov/ontologies/bibframe/agent> _:b10.
+          _:b10 a <http://id.loc.gov/ontologies/bibframe/Organization>;
+              <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> "Iranian Chemical Society", "United States. Army Map Service".
         TTL
       end
 
@@ -412,7 +412,7 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::AddedEntryFields, :vcr do
     context 'when mapping from multiple BF.Meeting URIs' do
       let(:ttl) do
         <<~TTL
-           <#{work_term}> <http://id.loc.gov/ontologies/bibframe/contribution> _:b11.
+          <#{work_term}> <http://id.loc.gov/ontologies/bibframe/contribution> _:b11.
           _:b11 a <http://id.loc.gov/ontologies/bibframe/Contribution>;
               <http://id.loc.gov/ontologies/bibframe/agent> _:b12.
           _:b12 a <http://id.loc.gov/ontologies/bibframe/Meeting>;
@@ -455,7 +455,6 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::AddedEntryFields, :vcr do
               <http://id.loc.gov/ontologies/bibframe/agent> _:b14.
           _:b14 a <http://id.loc.gov/ontologies/bibframe/Meeting>;
               <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> "Women and National Health Insurance Meeting", "Van Cliburn International Piano Competition".
-          #{'          '}
         TTL
       end
 
@@ -480,7 +479,7 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::AddedEntryFields, :vcr do
     context 'when mapping from multiple BF.Meeting URIs with roles' do
       let(:ttl) do
         <<~TTL
-           <#{work_term}> <http://id.loc.gov/ontologies/bibframe/contribution> _:b11.
+          <#{work_term}> <http://id.loc.gov/ontologies/bibframe/contribution> _:b11.
           _:b11 a <http://id.loc.gov/ontologies/bibframe/Contribution>;
               <http://id.loc.gov/ontologies/bibframe/agent> _:b12;
               <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ill>;

--- a/spec/rdf2marc/rdf2model/mappers/main_entry_fields_spec.rb
+++ b/spec/rdf2marc/rdf2model/mappers/main_entry_fields_spec.rb
@@ -358,7 +358,6 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::MainEntryFields, :vcr do
               <http://id.loc.gov/ontologies/bibframe/agent> _:b14.
           _:b14 a <http://id.loc.gov/ontologies/bibframe/Meeting>;
               <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> "Women and National Health Insurance Meeting", "Van Cliburn International Piano Competition".
-          #{'          '}
         TTL
       end
 


### PR DESCRIPTION
## Why was this change made?

I meant to do this as part of PR #109, but got distracted.  The poor alignment and the extra whitespace in these specs was also distracting.

## How was this change tested?



## Which documentation and/or configurations were updated?



