### PR TITLE
fallback to literal for label resolution if not uri

### DIFF
--- a/lib/rdf2marc/rdf2model/mappers/added_entry_fields.rb
+++ b/lib/rdf2marc/rdf2model/mappers/added_entry_fields.rb
@@ -61,7 +61,13 @@ module Rdf2marc
         end
 
         def relator_terms(role_uris)
-          role_uris.sort.map { |uri| Resolver.resolve_label(uri.value) }
+          role_uris.sort.map do |uri|
+            if uri.is_a?(RDF::Literal) || !Rdf2marc::Resolver.can_resolve?(uri.value, :label)
+              uri.value
+            else
+              Resolver.resolve_label(uri.value)
+            end
+          end
         end
       end
     end

--- a/lib/rdf2marc/resolver.rb
+++ b/lib/rdf2marc/resolver.rb
@@ -6,40 +6,34 @@ module Rdf2marc
     def self.resolve_model(uri, model_class)
       return nil if uri.nil?
 
-      resolver_class = resolver_class_for(uri)
-
-      if resolver_class.nil? || !resolver_class.method_defined?('resolve_model')
+      unless can_resolve?(uri, :model)
         Logger.warn("Resolving #{uri} to #{model_class} not supported.")
         return nil
       end
 
-      resolver_class.new.resolve_model(uri, model_class)
+      resolver_class_for(uri).new.resolve_model(uri, model_class)
     end
 
     def self.resolve_label(uri)
       return nil if uri.nil?
 
-      resolver_class = resolver_class_for(uri)
-
-      if resolver_class.nil? || !resolver_class.method_defined?('resolve_label')
+      unless can_resolve?(uri, :label)
         Logger.warn("Resolving label for #{uri} not supported.")
         return nil
       end
 
-      resolver_class.new.resolve_label(uri)
+      resolver_class_for(uri).new.resolve_label(uri)
     end
 
     def self.resolve_geographic_area_code(uri)
       return nil if uri.nil?
 
-      resolver_class = resolver_class_for(uri)
-
-      if resolver_class.nil? || !resolver_class.method_defined?('resolve_gac')
+      unless can_resolve?(uri, :gac)
         Logger.warn("Resolving geographic area code for #{uri} not supported.")
         return nil
       end
 
-      resolver_class.new.resolve_gac(uri)
+      resolver_class_for(uri).new.resolve_gac(uri)
     end
 
     # personal_name, family_name, corporate_name, meeting_name, uniform_title, named_event,
@@ -47,14 +41,20 @@ module Rdf2marc
     def self.resolve_type(uri)
       return nil if uri.nil?
 
-      resolver_class = resolver_class_for(uri)
-
-      if resolver_class.nil? || !resolver_class.method_defined?('resolve_type')
+      unless can_resolve?(uri, :type)
         Logger.warn("Resolving type for #{uri} not supported.")
         return nil
       end
 
-      resolver_class.new.resolve_type(uri)
+      resolver_class_for(uri).new.resolve_type(uri)
+    end
+
+    # provide URL and type trying to resolve (e.g. label) and this will indicate if it has a valid resolver
+    def self.can_resolve?(uri, uri_type)
+      resolver_class = resolver_class_for(uri)
+      return false unless resolver_class
+
+      resolver_class.method_defined?("resolve_#{uri_type}")
     end
 
     def self.resolver_class_for(uri)


### PR DESCRIPTION
## Why was this change made?

When resolving labels, fall back to the literal value if the provided URI is not actually a URI, or it is a URI that cannot be resolved.

To do:

- "If a URI is provided, but the URI is for an authority that cannot be resolved, and a label is provided for the URI and the label is different than the URI, use the label as the label."   How to deal with this?  The input to the `resolve_label` is a URI, so I'm not sure how you'd pass both a URI and a label? 

## How was this change tested?

To do:

- Need to update tests

## Which documentation and/or configurations were updated?



