### PR TITLE
Default URI statuses to "n" code when mapping the leader

### DIFF
--- a/lib/rdf2marc/rdf2model/mappers/leader.rb
+++ b/lib/rdf2marc/rdf2model/mappers/leader.rb
@@ -7,7 +7,6 @@ module Rdf2marc
       class Leader < BaseMapper
         def generate
           {
-            record_status: item.admin_metadata.query.path_first_literal([[BF.status, BF.Status], BF.code]),
             type: type,
             bibliographic_level: bibliographic_level,
             encoding_level: encoding_level,

--- a/spec/rdf2marc/rdf2model/mappers/leader_spec.rb
+++ b/spec/rdf2marc/rdf2model/mappers/leader_spec.rb
@@ -17,23 +17,47 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::Leader do
   end
 
   describe 'record status' do
-    let(:ttl) do
-      <<~TTL
-                          <#{admin_metadata_term}> <http://id.loc.gov/ontologies/bibframe/status> _:b17.
-        _:b17 a <http://id.loc.gov/ontologies/bibframe/Status>;
+    context 'when a literal' do
+      let(:ttl) do
+        <<~TTL
+          <#{admin_metadata_term}> <http://id.loc.gov/ontologies/bibframe/status> _:b17.
+          _:b17 a <http://id.loc.gov/ontologies/bibframe/Status>;
             <http://id.loc.gov/ontologies/bibframe/code> "a"@eng.
-      TTL
+        TTL
+      end
+
+      let(:model) do
+        {
+          bibliographic_level: 'item',
+          type: 'language_material'
+          # NOTE: It is not mapped; it is defaulted in the Leader struct
+          # record_status: 'a'
+        }
+      end
+
+      include_examples 'mapper', described_class
     end
 
-    let(:model) do
-      {
-        bibliographic_level: 'item',
-        type: 'language_material',
-        record_status: 'a'
-      }
-    end
+    context 'when an mstatus URI' do
+      let(:ttl) do
+        <<~TTL
+          <#{admin_metadata_term}> <http://id.loc.gov/ontologies/bibframe/status> _:b17.
+          _:b17 a <http://id.loc.gov/ontologies/bibframe/Status>;
+            <http://id.loc.gov/ontologies/bibframe/code> <http://id.loc.gov/vocabulary/mstatus/cancinv>.
+        TTL
+      end
 
-    include_examples 'mapper', described_class
+      let(:model) do
+        {
+          bibliographic_level: 'item',
+          type: 'language_material'
+          # NOTE: It is not mapped; it is defaulted in the Leader struct
+          # record_status: 'n'
+        }
+      end
+
+      include_examples 'mapper', described_class
+    end
   end
 
   describe 'type' do


### PR DESCRIPTION
Connects to #141


## Why was this change made?

This commit allows our data to continue using URI statuses (such as http://id.loc.gov/vocabulary/mstatus/n) without breaking the leader mapping. Current strategy is defaulting to the "n" code string.


## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None

