### PR TITLE
Shrink lambda layer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,8 +95,12 @@ jobs:
     executor: default
     steps:
       - checkout
-      - ruby/install-deps:
-          key: rdf2marc
+      - run:
+          name: Install dependencies
+          command: |
+            bundle config set --local deployment 'true'
+            bundle config set --local without 'test development'
+            bundler install
       - run:
           name: Build layer zip
           command: |


### PR DESCRIPTION
closes #143

## Why was this change made?
So that the layer can be deployed to AWS.


## How was this change tested?
CI


## Which documentation and/or configurations were updated?



