### PR TITLE
Wait

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ commands:
           aws lambda update-function-configuration --function-name << parameters.function-name >> --layers $latest_layer_version_arn
 
           aws lambda update-function-code --function-name << parameters.function-name >> --zip-file fileb://lambda.zip
+          aws lambda wait function-updated --function-name << parameters.function-name >>
           aws lambda publish-version --function-name << parameters.function-name >>
 jobs:
   build:


### PR DESCRIPTION
## Why was this change made?
Deploys to AWS were failing with 
```
An error occurred (ResourceConflictException) when calling the PublishVersion operation: The operation cannot be performed at this time. An update is in progress for resource: arn:aws:lambda:*********:975822730059:function:*******-rdf2marc-production

Exited with code exit status 254
```


## How was this change tested?
Circle.


## Which documentation and/or configurations were updated?



