### PR TITLE
Use 180 if no 150 for topical term mapping.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,7 @@ GEM
     zeitwerk (2.5.1)
 
 PLATFORMS
+  ruby
   x86_64-darwin-19
   x86_64-linux
 

--- a/lib/rdf2marc/resolver/id_loc_gov_resolvers/topical_term.rb
+++ b/lib/rdf2marc/resolver/id_loc_gov_resolvers/topical_term.rb
@@ -6,7 +6,7 @@ module Rdf2marc
       # Mapper for topical terms.
       class TopicalTerm < BaseMapper
         def map
-          field = marc_record['150']
+          field = marc_record['150'] || marc_record['180']
           {
             thesaurus: 'lcsh',
             topical_term_or_geo_name: subfield_value(field, 'a'),

--- a/spec/rdf2marc/resolver/id_loc_gov_resolvers/topical_term_spec.rb
+++ b/spec/rdf2marc/resolver/id_loc_gov_resolvers/topical_term_spec.rb
@@ -42,4 +42,5 @@ RSpec.describe Rdf2marc::Resolver::IdLocGovResolvers::TopicalTerm do
   end
 
   include_examples 'resolver_mapper', described_class, '150', Rdf2marc::Models::SubjectAccessField::TopicalTerm
+  include_examples 'resolver_mapper', described_class, '180', Rdf2marc::Models::SubjectAccessField::TopicalTerm
 end


### PR DESCRIPTION
closes #161

## Why was this change made?
Bug fix.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



