### PR TITLE
Transliterated title

### DIFF
--- a/lib/rdf2marc/rdf2model/mappers/title_fields.rb
+++ b/lib/rdf2marc/rdf2model/mappers/title_fields.rb
@@ -22,15 +22,11 @@ module Rdf2marc
         private
 
         def translated_titles
-          # VariantTitles where variantType='translated'
-          translated_title_terms = item.instance.query.path_all([[BF.title, BF.VariantTitle]])
-          translated_title_terms.keep_if do |title_term|
-            item.instance.query.path_all_literal([BF.variantType], subject_term: title_term).include?('translated')
-          end
-
+          translated_title_terms = item.instance.query.path_all([[BF.title, BFLC.TransliteratedTitle]])
           translated_title_terms.sort.map do |title_term|
             {
               title: item.instance.query.path_first_literal([BF.mainTitle], subject_term: title_term),
+              remainder_of_title: item.instance.query.path_first_literal([BF.subtitle], subject_term: title_term),
               part_numbers: item.instance.query.path_all_literal([BF.partNumber], subject_term: title_term).sort,
               part_names: item.instance.query.path_all_literal([BF.partName], subject_term: title_term).sort
             }
@@ -56,11 +52,11 @@ module Rdf2marc
         def variant_titles
           # VariantTitle and ParallelTitle
           variant_title_terms = item.instance.query.path_all([[BF.title, BF.VariantTitle]])
-          # Filter variant titles where variantType='translated' or 'former'
+          # Filter variant titles where variantType='former'
           variant_title_terms.delete_if do |title_term|
             variant_types = item.instance.query.path_all_literal([BF.variantType],
                                                                  subject_term: title_term)
-            variant_types.include?('translated') || variant_types.include?('former')
+            variant_types.include?('former')
           end
 
           parallel_title_terms = item.instance.query.path_all([[BF.title, BF.ParallelTitle]])

--- a/spec/rdf2marc/rdf2model/mappers/title_fields_spec.rb
+++ b/spec/rdf2marc/rdf2model/mappers/title_fields_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::TitleFields do
   describe 'translated titles' do
     let(:ttl) do
       <<~TTL
-               <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/title> _:b41.
-        _:b41 a <http://id.loc.gov/ontologies/bibframe/VariantTitle>;
-          <http://id.loc.gov/ontologies/bibframe/mainTitle> "World of art"@eng;
-          <http://id.loc.gov/ontologies/bibframe/partName> "Selected Internet resources"@eng, "Student handbook"@eng;
-          <http://id.loc.gov/ontologies/bibframe/variantType> "translated"@eng, "acronym"@eng.
+        <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/title> _:b666 .
+        _:b666 a <http://id.loc.gov/ontologies/bflc/TransliteratedTitle>;
+          <http://id.loc.gov/ontologies/bibframe/mainTitle> "Abḥathu ‘an Laylá"@ar-Latn-t-ar-m0-alaloc;
+          <http://id.loc.gov/ontologies/bibframe/subtitle> "riwāyah"@ar-Latn-t-ar-m0-alaloc;
+          <http://id.loc.gov/ontologies/bibframe/partName> "partName"@eng .
       TTL
     end
 
@@ -42,8 +42,9 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::TitleFields do
       {
         translated_titles: [
           {
-            part_names: ['Selected Internet resources', 'Student handbook'],
-            title: 'World of art'
+            title: 'Abḥathu ‘an Laylá',
+            remainder_of_title: 'riwāyah',
+            part_names: ['partName']
           }
         ]
       }

--- a/spec/rdf2marc/rdf2model/mappers/title_fields_spec.rb
+++ b/spec/rdf2marc/rdf2model/mappers/title_fields_spec.rb
@@ -57,17 +57,17 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::TitleFields do
     # This contains an extra title, which is ignored.
     let(:ttl) do
       <<~TTL
-               <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/title> _:b43 .
-            _:b43 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Title> .
-        _:b43 <http://id.loc.gov/ontologies/bibframe/mainTitle> "Distribution of the principal kinds of soil"@eng .
-            _:b43 <http://id.loc.gov/ontologies/bibframe/subtitle> "orders, suborders, and great groups : National Soil Survey Classification of 1967"@eng .
-            _:b43 <http://id.loc.gov/ontologies/bibframe/partNumber> "Part one"@eng .
-            _:b43 <http://id.loc.gov/ontologies/bibframe/partNumber> "Part B"@eng .
-            _:b43 <http://id.loc.gov/ontologies/bibframe/partName> "Student handbook"@eng .
-            _:b43 <http://id.loc.gov/ontologies/bibframe/partName> "Supplement"@eng .
-            <> <http://id.loc.gov/ontologies/bibframe/title> _:b44 .
-            _:b44 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Title> .
-        _:b44 <http://id.loc.gov/ontologies/bibframe/mainTitle> "The royal gazette"@eng .
+        <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/title> _:b43 .
+        _:b43 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Title>;
+          <http://id.loc.gov/ontologies/bibframe/mainTitle> "Distribution of the principal kinds of soil"@eng;
+          <http://id.loc.gov/ontologies/bibframe/subtitle> "orders, suborders, and great groups : National Soil Survey Classification of 1967"@eng;
+          <http://id.loc.gov/ontologies/bibframe/partNumber> "Part one"@eng;
+          <http://id.loc.gov/ontologies/bibframe/partNumber> "Part B"@eng;
+          <http://id.loc.gov/ontologies/bibframe/partName> "Student handbook"@eng;
+          <http://id.loc.gov/ontologies/bibframe/partName> "Supplement"@eng .
+        <> <http://id.loc.gov/ontologies/bibframe/title> _:b44 .
+        _:b44 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Title>;
+          <http://id.loc.gov/ontologies/bibframe/mainTitle> "The royal gazette"@eng .
       TTL
     end
 
@@ -109,16 +109,16 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::TitleFields do
   describe 'variant titles' do
     let(:ttl) do
       <<~TTL
-               <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/title> _:b45 .
-        _:b45 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/ParallelTitle> .
-        _:b45 <http://id.loc.gov/ontologies/bibframe/mainTitle> "The Year book of medicine"@eng .
-        _:b45 <http://id.loc.gov/ontologies/bibframe/subtitle> "facts or fiction"@eng .
+        <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/title> _:b45 .
+        _:b45 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/ParallelTitle>;
+          <http://id.loc.gov/ontologies/bibframe/mainTitle> "The Year book of medicine"@eng;
+          <http://id.loc.gov/ontologies/bibframe/subtitle> "facts or fiction"@eng .
         <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/title> _:b46 .
-        _:b46 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/VariantTitle> .
-        _:b46 <http://id.loc.gov/ontologies/bibframe/mainTitle> "World of art"@eng .
-        _:b46 <http://id.loc.gov/ontologies/bibframe/partName> "Selected Internet resources"@eng .
-        _:b46 <http://id.loc.gov/ontologies/bibframe/partName> "Student handbook"@eng .
-        _:b46 <http://id.loc.gov/ontologies/bibframe/variantType> "cover"@eng .
+        _:b46 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/VariantTitle>;
+          <http://id.loc.gov/ontologies/bibframe/mainTitle> "World of art"@eng;
+          <http://id.loc.gov/ontologies/bibframe/partName> "Selected Internet resources"@eng;
+          <http://id.loc.gov/ontologies/bibframe/partName> "Student handbook"@eng;
+          <http://id.loc.gov/ontologies/bibframe/variantType> "cover"@eng .
       TTL
     end
 


### PR DESCRIPTION
## Why was this change made?

Fixes #160

Note that discussions indicated that TransliteratedTitle should become "translated_title" in the model which becomes 242 in MARC ... and the old mapping of translated_title could be jettisoned in favor of the new.

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?



