### PR TITLE
Illustrative content

### DIFF
--- a/lib/rdf2marc/model2marc/control_field_008.rb
+++ b/lib/rdf2marc/model2marc/control_field_008.rb
@@ -19,6 +19,8 @@ module Rdf2marc
           field_value[6..14] = '|||||||||'
         end
         field_value[15..17] = model.place
+        # Book Illustrative Context
+        field_value[18] = 'a' if model.book_illustrative_content.present?
         # Language
         field_value[35..37] = model.language[0..2] if model.language
         # Modified record

--- a/lib/rdf2marc/model2marc/field_300.rb
+++ b/lib/rdf2marc/model2marc/field_300.rb
@@ -10,6 +10,7 @@ module Rdf2marc
 
       def build
         append_repeatable('a', model.extents)
+        append('b', model.other_physical_details)
         append_repeatable('c', model.dimensions)
         append('3', model.materials_specified)
       end

--- a/lib/rdf2marc/models/control_field/general_info.rb
+++ b/lib/rdf2marc/models/control_field/general_info.rb
@@ -9,6 +9,7 @@ module Rdf2marc
         attribute? :date1, Types::String
         attribute? :place, Types::String.default('xx').constrained(min_size: 2, max_size: 3)
         attribute? :language, Types::String
+        attribute? :book_illustrative_content, Types::String
       end
     end
   end

--- a/lib/rdf2marc/models/physical_description_field/physical_description.rb
+++ b/lib/rdf2marc/models/physical_description_field/physical_description.rb
@@ -6,6 +6,7 @@ module Rdf2marc
       # Model for 300 - Physical Description.
       class PhysicalDescription < Struct
         attribute? :extents, Types::Array.of(Types::String)
+        attribute? :other_physical_details, Types::String
         attribute? :dimensions, Types::Array.of(Types::String)
         attribute? :materials_specified, Types::String
       end

--- a/lib/rdf2marc/rdf2model/mappers/control_fields.rb
+++ b/lib/rdf2marc/rdf2model/mappers/control_fields.rb
@@ -12,7 +12,8 @@ module Rdf2marc
               place: place,
               date_entered: date_entered,
               date1: item.instance.query.path_first_literal([[BF.provisionActivity, BF.Publication], [BF.date]]),
-              language: language
+              language: language,
+              book_illustrative_content: book_illustrative_content
             }
           }
         end
@@ -50,6 +51,14 @@ module Rdf2marc
           return nil if language_uri.nil? || !language_uri.start_with?(%r{https?://id.loc.gov/vocabulary/languages/})
 
           language_uri.sub(%r{^https?://id.loc.gov/vocabulary/languages/}, '')
+        end
+
+        def book_illustrative_content
+          illustrative_content_uri = item.instance.query.path_first_uri([BF.illustrativeContent]) ||
+                                     item.work.query.path_first_uri([BF.illustrativeContent])
+          return nil if illustrative_content_uri.blank?
+
+          LiteralOrRemoteResolver.resolve_label(term: illustrative_content_uri, item: item)
         end
       end
     end

--- a/lib/rdf2marc/rdf2model/mappers/physical_description_fields.rb
+++ b/lib/rdf2marc/rdf2model/mappers/physical_description_fields.rb
@@ -18,21 +18,29 @@ module Rdf2marc
 
         def physical_descriptions
           extent_terms = item.instance.query.path_all([[BF.extent, BF.Extent]])
-          extent_physical_description = extent_terms.sort.map do |extent_term|
+
+          # can have multiple illustrativeContent, but only using one
+          illustrative_content_uri = item.instance.query.path_first_uri([BF.illustrativeContent]) ||
+                                     item.work.query.path_first_uri([BF.illustrativeContent])
+          if illustrative_content_uri
+            other_physical_details = LiteralOrRemoteResolver.resolve_label(term: illustrative_content_uri, item: item)
+          end
+          extent_physical_descriptions = extent_terms.sort.map do |extent_term|
             {
               extents: item.instance.query.path_all_literal([RDF::RDFS.label], subject_term: extent_term).sort,
               # Can be multiple notes, but only using one.
               materials_specified: item.instance.query.path_first_literal([[BF.note, BF.Note],
-                                                                           RDF::RDFS.label], subject_term: extent_term)
+                                                                           RDF::RDFS.label], subject_term: extent_term),
+              other_physical_details: other_physical_details
             }
           end
           dimensions = item.instance.query.path_all_literal([BF.dimensions]).sort
-          if extent_physical_description.length == 1 && dimensions.length == 1
-            return [extent_physical_description.first.merge(dimensions: dimensions)]
+          if extent_physical_descriptions.length == 1 && dimensions.length == 1
+            return [extent_physical_descriptions.first.merge(dimensions: dimensions)]
           end
 
-          extent_physical_description << { dimensions: dimensions } if dimensions.present?
-          extent_physical_description
+          extent_physical_descriptions << { dimensions: dimensions } if dimensions.present?
+          extent_physical_descriptions
         end
 
         def media_types

--- a/lib/rdf2marc/rdf2model/mappers/physical_description_fields.rb
+++ b/lib/rdf2marc/rdf2model/mappers/physical_description_fields.rb
@@ -26,14 +26,13 @@ module Rdf2marc
                                                                            RDF::RDFS.label], subject_term: extent_term)
             }
           end
-          dimensions = {
-            dimensions: item.instance.query.path_all_literal([BF.dimensions]).sort
-          }
-          if extent_physical_description.length == 1 && dimensions[:dimensions].length == 1
-            return [extent_physical_description.first.merge(dimensions)]
+          dimensions = item.instance.query.path_all_literal([BF.dimensions]).sort
+          if extent_physical_description.length == 1 && dimensions.length == 1
+            return [extent_physical_description.first.merge(dimensions: dimensions)]
           end
 
-          extent_physical_description + [dimensions]
+          extent_physical_description << { dimensions: dimensions } if dimensions.present?
+          extent_physical_description
         end
 
         def media_types

--- a/spec/cassettes/Rdf2marc_Rdf2model_Mappers_ControlFields/general_info_book_illustrative_content/maps_to_model.yml
+++ b/spec/cassettes/Rdf2marc_Rdf2model_Mappers_ControlFields/general_info_book_illustrative_content/maps_to_model.yml
@@ -1,0 +1,119 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://id.loc.gov/vocabulary/millus/ill.skos.nt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby RDF.rb/3.1.15
+      Accept:
+      - text/turtle, text/rdf+turtle, application/turtle;q=0.2, application/x-turtle;q=0.2,
+        application/ld+json, application/x-ld+json, application/rdf+xml, application/n-triples,
+        text/plain;q=0.2, application/n-quads, text/x-nquads;q=0.2, */*;q=0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Thu, 09 Dec 2021 00:26:24 GMT
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - max-age=3600
+      Expires:
+      - Thu, 09 Dec 2021 01:26:24 GMT
+      Location:
+      - https://id.loc.gov/vocabulary/millus/ill.skos.nt
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 6baa1a111e3d3b34-SJC
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Thu, 09 Dec 2021 00:26:24 GMT
+- request:
+    method: get
+    uri: https://id.loc.gov/vocabulary/millus/ill.skos.nt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby RDF.rb/3.1.15
+      Accept:
+      - text/turtle, text/rdf+turtle, application/turtle;q=0.2, application/x-turtle;q=0.2,
+        application/ld+json, application/x-ld+json, application/rdf+xml, application/n-triples,
+        text/plain;q=0.2, application/n-quads, text/x-nquads;q=0.2, */*;q=0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 09 Dec 2021 00:26:25 GMT
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Method:
+      - HEAD, POST, GET, OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With
+      Access-Control-Expose-Headers:
+      - Content-Type, Cache-Control, X-URI, X-PrefLabel
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Preflabel:
+      - Illustrations
+      X-Uri:
+      - http://id.loc.gov/vocabulary/millus/ill
+      Cache-Control:
+      - public, max-age=2419200
+      X-Varnish:
+      - 376457851 367752864
+      Age:
+      - '1412844'
+      Via:
+      - 1.1 varnish (Varnish/6.0)
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 6baa1a115b43711a-SJC
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        <http://id.loc.gov/vocabulary/millus/ill> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+        <http://id.loc.gov/vocabulary/millus/ill> <http://www.w3.org/2004/02/skos/core#prefLabel> "Illustrations" .
+        <http://id.loc.gov/vocabulary/millus/ill> <http://www.w3.org/2004/02/skos/core#definition> "Resource contains illustrations, type unspecified"@en .
+        <http://id.loc.gov/vocabulary/millus/ill> <http://www.w3.org/2004/02/skos/core#historyNote> "008BK/18-21 - a"@en .
+        <http://id.loc.gov/vocabulary/millus/ill> <http://www.w3.org/2004/02/skos/core#notation> "ill" .
+        <http://id.loc.gov/vocabulary/millus/ill> <http://www.w3.org/2004/02/skos/core#inScheme> <http://id.loc.gov/vocabulary/millus> .
+  recorded_at: Thu, 09 Dec 2021 00:26:25 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/Rdf2marc_Rdf2model_Mappers_PhysicalDescriptionFields/physical_descriptions/with_a_single_extent_and_illustrativeContent/maps_to_model.yml
+++ b/spec/cassettes/Rdf2marc_Rdf2model_Mappers_PhysicalDescriptionFields/physical_descriptions/with_a_single_extent_and_illustrativeContent/maps_to_model.yml
@@ -1,0 +1,119 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://id.loc.gov/vocabulary/millus/ill.skos.nt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby RDF.rb/3.1.15
+      Accept:
+      - text/turtle, text/rdf+turtle, application/turtle;q=0.2, application/x-turtle;q=0.2,
+        application/ld+json, application/x-ld+json, application/rdf+xml, application/n-triples,
+        text/plain;q=0.2, application/n-quads, text/x-nquads;q=0.2, */*;q=0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Wed, 08 Dec 2021 23:32:52 GMT
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - max-age=3600
+      Expires:
+      - Thu, 09 Dec 2021 00:32:52 GMT
+      Location:
+      - https://id.loc.gov/vocabulary/millus/ill.skos.nt
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 6ba9cba6eb75711b-SJC
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 08 Dec 2021 23:32:52 GMT
+- request:
+    method: get
+    uri: https://id.loc.gov/vocabulary/millus/ill.skos.nt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Ruby RDF.rb/3.1.15
+      Accept:
+      - text/turtle, text/rdf+turtle, application/turtle;q=0.2, application/x-turtle;q=0.2,
+        application/ld+json, application/x-ld+json, application/rdf+xml, application/n-triples,
+        text/plain;q=0.2, application/n-quads, text/x-nquads;q=0.2, */*;q=0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 08 Dec 2021 23:32:53 GMT
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Method:
+      - HEAD, POST, GET, OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With
+      Access-Control-Expose-Headers:
+      - Content-Type, Cache-Control, X-URI, X-PrefLabel
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Preflabel:
+      - Illustrations
+      X-Uri:
+      - http://id.loc.gov/vocabulary/millus/ill
+      Cache-Control:
+      - public, max-age=2419200
+      X-Varnish:
+      - 378161244 367752864
+      Age:
+      - '1409632'
+      Via:
+      - 1.1 varnish (Varnish/6.0)
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 6ba9cba72bc9ed6b-SJC
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        <http://id.loc.gov/vocabulary/millus/ill> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+        <http://id.loc.gov/vocabulary/millus/ill> <http://www.w3.org/2004/02/skos/core#prefLabel> "Illustrations" .
+        <http://id.loc.gov/vocabulary/millus/ill> <http://www.w3.org/2004/02/skos/core#definition> "Resource contains illustrations, type unspecified"@en .
+        <http://id.loc.gov/vocabulary/millus/ill> <http://www.w3.org/2004/02/skos/core#historyNote> "008BK/18-21 - a"@en .
+        <http://id.loc.gov/vocabulary/millus/ill> <http://www.w3.org/2004/02/skos/core#notation> "ill" .
+        <http://id.loc.gov/vocabulary/millus/ill> <http://www.w3.org/2004/02/skos/core#inScheme> <http://id.loc.gov/vocabulary/millus> .
+  recorded_at: Wed, 08 Dec 2021 23:32:53 GMT
+recorded_with: VCR 6.0.0

--- a/spec/rdf2marc/model2marc/control_field_008_spec.rb
+++ b/spec/rdf2marc/model2marc/control_field_008_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Rdf2marc::Model2marc::ControlField008 do
             date_entered: Date.new(2020, 10, 15),
             date1: '202x',
             place: 'gau',
-            language: 'ace'
+            language: 'ace',
+            book_illustrative_content: 'Illustrations'
           }
         }
       }

--- a/spec/rdf2marc/model2marc/control_field_008_spec.rb
+++ b/spec/rdf2marc/model2marc/control_field_008_spec.rb
@@ -41,4 +41,27 @@ RSpec.describe Rdf2marc::Model2marc::ControlField008 do
 
     include_examples 'fields', '008'
   end
+
+  context 'with model with illustrative_content' do
+    let(:model) do
+      {
+        control_fields: {
+          general_info: {
+            date_entered: Date.new(2020, 10, 15),
+            date1: '202x',
+            place: 'gau',
+            language: 'ace'
+          }
+        }
+      }
+    end
+
+    let(:expected_fields) { ['008 201015s202u    gaua                ace||'] }
+
+    before do
+      allow(Date).to receive(:today).and_return(Date.new(2020, 10, 1))
+    end
+
+    include_examples 'fields', '008'
+  end
 end

--- a/spec/rdf2marc/model2marc/field_300_spec.rb
+++ b/spec/rdf2marc/model2marc/field_300_spec.rb
@@ -1,29 +1,65 @@
 # frozen_string_literal: true
 
 RSpec.describe Rdf2marc::Model2marc::Field300 do
-  let(:model) do
-    {
-      physical_description_fields: {
-        physical_descriptions: [
-          {
-            extents: %w[extent1 extent2],
-            dimensions: %w[dimension1 dimension2],
-            materials_specified: 'materials_specified1'
-          },
-          {
-            materials_specified: 'materials_specified2'
-          }
-        ]
+  context 'with multiple extents and dimensions in single physical description' do
+    let(:model) do
+      {
+        physical_description_fields: {
+          physical_descriptions: [
+            {
+              extents: %w[extent1 extent2],
+              dimensions: %w[dimension1 dimension2],
+              materials_specified: 'materials_specified1'
+            },
+            {
+              materials_specified: 'materials_specified2'
+            }
+          ]
+        }
       }
-    }
+    end
+
+    let(:expected_fields) do
+      [
+        '300    $a extent1 $a extent2 $c dimension1 $c dimension2 $3 materials_specified1',
+        '300    $3 materials_specified2'
+      ]
+    end
+
+    include_examples 'fields', '300'
   end
 
-  let(:expected_fields) do
-    [
-      '300    $a extent1 $a extent2 $c dimension1 $c dimension2 $3 materials_specified1',
-      '300    $3 materials_specified2'
-    ]
-  end
+  context 'with single extents and dimensions in multiple physical descriptions' do
+    let(:model) do
+      {
+        physical_description_fields: {
+          physical_descriptions: [
+            {
+              extents: %w[extent1],
+              dimensions: %w[dimension1 dimensionA],
+              materials_specified: 'materials_specified1'
+            },
+            {
+              extents: %w[extent2 extent3],
+              dimensions: %w[dimension2],
+              materials_specified: 'materials_specified1'
+            },
+            {
+              materials_specified: 'materials_specified2'
+            }
+          ]
+        }
+      }
+    end
 
-  include_examples 'fields', '300'
+    let(:expected_fields) do
+      [
+        '300    $a extent1 $c dimension1 $c dimensionA $3 materials_specified1',
+        '300    $a extent2 $a extent3 $c dimension2 $3 materials_specified1',
+        '300    $3 materials_specified2'
+      ]
+    end
+
+    include_examples 'fields', '300'
+  end
 end

--- a/spec/rdf2marc/model2marc/field_300_spec.rb
+++ b/spec/rdf2marc/model2marc/field_300_spec.rb
@@ -62,4 +62,28 @@ RSpec.describe Rdf2marc::Model2marc::Field300 do
 
     include_examples 'fields', '300'
   end
+
+  context 'with other_physical_details physical descriptions' do
+    let(:model) do
+      {
+        physical_description_fields: {
+          physical_descriptions: [
+            {
+              extents: %w[extent1],
+              other_physical_details: 'Illustrations',
+              dimensions: %w[dimension1]
+            }
+          ]
+        }
+      }
+    end
+
+    let(:expected_fields) do
+      [
+        '300    $a extent1 $b Illustrations $c dimension1'
+      ]
+    end
+
+    include_examples 'fields', '300'
+  end
 end

--- a/spec/rdf2marc/rdf2model/mappers/control_fields_spec.rb
+++ b/spec/rdf2marc/rdf2model/mappers/control_fields_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::ControlFields, :vcr do
   describe 'general info place' do
     let(:ttl) do
       <<~TTL
-                  <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/provisionActivity> _:b9.
+        <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/provisionActivity> _:b9.
         _:b9 a <http://id.loc.gov/ontologies/bibframe/Publication>;
             <http://id.loc.gov/ontologies/bibframe/place> <http://id.loc.gov/authorities/names/n78003886>.
         <http://id.loc.gov/authorities/names/n78003886> <http://www.w3.org/2000/01/rdf-schema#label> "Palo Alto (Miss.)".
@@ -79,7 +79,7 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::ControlFields, :vcr do
   describe 'general info date1' do
     let(:ttl) do
       <<~TTL
-                  <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/provisionActivity> _:b10.
+        <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/provisionActivity> _:b10.
         _:b10 a <http://id.loc.gov/ontologies/bibframe/Publication>;
             <http://id.loc.gov/ontologies/bibframe/date> "2020-10-12"@eng.
       TTL
@@ -100,7 +100,7 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::ControlFields, :vcr do
   describe 'general info language' do
     let(:ttl) do
       <<~TTL
-                  <#{work_term}> <http://id.loc.gov/ontologies/bibframe/language> <http://id.loc.gov/vocabulary/languages/ace>.
+        <#{work_term}> <http://id.loc.gov/ontologies/bibframe/language> <http://id.loc.gov/vocabulary/languages/ace>.
         <http://id.loc.gov/vocabulary/languages/ace> <http://www.w3.org/2000/01/rdf-schema#label> "Achinese".
         <> <http://id.loc.gov/ontologies/bibframe/language> <http://id.loc.gov/vocabulary/languages/bug>.
         <http://id.loc.gov/vocabulary/languages/bug> <http://www.w3.org/2000/01/rdf-schema#label> "Bugis".
@@ -111,6 +111,25 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::ControlFields, :vcr do
       {
         general_info: {
           language: 'ace',
+          place: 'xx'
+        }
+      }
+    end
+
+    include_examples 'mapper', described_class
+  end
+
+  describe 'general info book illustrative content' do
+    let(:ttl) do
+      <<~TTL
+        <#{work_term}> <http://id.loc.gov/ontologies/bibframe/illustrativeContent> <http://id.loc.gov/vocabulary/millus/ill> .
+      TTL
+    end
+
+    let(:model) do
+      {
+        general_info: {
+          book_illustrative_content: 'Illustrations',
           place: 'xx'
         }
       }

--- a/spec/rdf2marc/rdf2model/mappers/physical_description_fields_spec.rb
+++ b/spec/rdf2marc/rdf2model/mappers/physical_description_fields_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rdf2marc/rdf2model/mappers/mappers_shared_examples'
 
-RSpec.describe Rdf2marc::Rdf2model::Mappers::PhysicalDescriptionFields do
+RSpec.describe Rdf2marc::Rdf2model::Mappers::PhysicalDescriptionFields, :vcr do
   context 'with minimal graph' do
     let(:ttl) { '' }
 
@@ -95,6 +95,30 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::PhysicalDescriptionFields do
             {
               extents: ['250 pages'],
               dimensions: ['24 cm']
+            }
+          ]
+        }
+      end
+
+      include_examples 'mapper', described_class
+    end
+
+    context 'with a single extent and illustrativeContent' do
+      let(:ttl) do
+        <<~TTL
+          <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/extent> _:b38.
+          _:b38 a <http://id.loc.gov/ontologies/bibframe/Extent>;
+              <http://www.w3.org/2000/01/rdf-schema#label> "1 folded sheet (5 pages)"@eng.
+          <#{work_term}> <http://id.loc.gov/ontologies/bibframe/illustrativeContent> <http://id.loc.gov/vocabulary/millus/ill> .
+        TTL
+      end
+
+      let(:model) do
+        {
+          physical_descriptions: [
+            {
+              extents: ['1 folded sheet (5 pages)'],
+              other_physical_details: 'Illustrations'
             }
           ]
         }

--- a/spec/rdf2marc/rdf2model/mappers/physical_description_fields_spec.rb
+++ b/spec/rdf2marc/rdf2model/mappers/physical_description_fields_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::PhysicalDescriptionFields do
     context 'with multiple extents' do
       let(:ttl) do
         <<~TTL
-                                    <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/extent> _:b38.
+          <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/extent> _:b38.
           _:b38 a <http://id.loc.gov/ontologies/bibframe/Extent>;
               <http://www.w3.org/2000/01/rdf-schema#label> "149 pages"@eng, "1 score (16 p.)"@eng;
               <http://id.loc.gov/ontologies/bibframe/note> _:b39.
@@ -79,7 +79,7 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::PhysicalDescriptionFields do
   describe 'media types' do
     let(:ttl) do
       <<~TTL
-                                  <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/media> <http://id.loc.gov/vocabulary/mediaTypes/n>.
+        <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/media> <http://id.loc.gov/vocabulary/mediaTypes/n>.
         <http://id.loc.gov/vocabulary/mediaTypes/n> <http://www.w3.org/2000/01/rdf-schema#label> "unmediated".
         <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/media> <http://id.loc.gov/vocabulary/mediaTypes/h>.
         <http://id.loc.gov/vocabulary/mediaTypes/h> <http://www.w3.org/2000/01/rdf-schema#label> "microform".
@@ -109,7 +109,7 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::PhysicalDescriptionFields do
   describe 'carrier types' do
     let(:ttl) do
       <<~TTL
-                                  <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/carrier> <http://id.loc.gov/vocabulary/carriers/nc>.
+        <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/carrier> <http://id.loc.gov/vocabulary/carriers/nc>.
         <http://id.loc.gov/vocabulary/carriers/nc> <http://www.w3.org/2000/01/rdf-schema#label> "volume".
         <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/carrier> <http://id.loc.gov/vocabulary/carriers/sg>.
         <http://id.loc.gov/vocabulary/carriers/sg> <http://www.w3.org/2000/01/rdf-schema#label> "audio cartridge".
@@ -139,7 +139,7 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::PhysicalDescriptionFields do
   describe 'content types' do
     let(:ttl) do
       <<~TTL
-                                  <#{work_term}> <http://id.loc.gov/ontologies/bibframe/content> <http://id.loc.gov/vocabulary/contentTypes/txt>.
+        <#{work_term}> <http://id.loc.gov/ontologies/bibframe/content> <http://id.loc.gov/vocabulary/contentTypes/txt>.
         <http://id.loc.gov/vocabulary/contentTypes/txt> <http://www.w3.org/2000/01/rdf-schema#label> "text".
         <#{work_term}> <http://id.loc.gov/ontologies/bibframe/content> <http://id.loc.gov/vocabulary/contentTypes/sti>.
         <http://id.loc.gov/vocabulary/contentTypes/sti> <http://www.w3.org/2000/01/rdf-schema#label> "still image".

--- a/spec/rdf2marc/rdf2model/mappers/physical_description_fields_spec.rb
+++ b/spec/rdf2marc/rdf2model/mappers/physical_description_fields_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::PhysicalDescriptionFields do
 
     let(:model) do
       {
-        physical_descriptions: [{}]
       }
     end
 
@@ -89,7 +88,6 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::PhysicalDescriptionFields do
 
     let(:model) do
       {
-        physical_descriptions: [{}],
         media_types: [
           {
             authority_control_number_uri: 'http://id.loc.gov/vocabulary/mediaTypes/h',
@@ -120,7 +118,6 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::PhysicalDescriptionFields do
 
     let(:model) do
       {
-        physical_descriptions: [{}],
         carrier_types: [
           {
             authority_control_number_uri: 'http://id.loc.gov/vocabulary/carriers/nc',
@@ -151,7 +148,6 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::PhysicalDescriptionFields do
 
     let(:model) do
       {
-        physical_descriptions: [{}],
         content_types: [
           {
             authority_control_number_uri: 'http://id.loc.gov/vocabulary/contentTypes/sti',

--- a/spec/rdf2marc/rdf2model/mappers/physical_description_fields_spec.rb
+++ b/spec/rdf2marc/rdf2model/mappers/physical_description_fields_spec.rb
@@ -51,6 +51,34 @@ RSpec.describe Rdf2marc::Rdf2model::Mappers::PhysicalDescriptionFields do
       include_examples 'mapper', described_class
     end
 
+    context 'with a single extent and multiple dimensions' do
+      let(:ttl) do
+        <<~TTL
+          <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/extent> _:b40.
+          _:b40 a <http://id.loc.gov/ontologies/bibframe/Extent>;
+              <http://www.w3.org/2000/01/rdf-schema#label> "1 sound disc (20 min.)"@eng.
+          <#{instance_term}> <http://id.loc.gov/ontologies/bibframe/dimensions> "10 x 27 cm"@eng ;
+            <http://id.loc.gov/ontologies/bibframe/dimensions> "7 1/4 x 3 1/2 in."@eng ;
+            <http://id.loc.gov/ontologies/bibframe/dimensions> "1/4 in. tape"@eng.
+        TTL
+      end
+
+      let(:model) do
+        {
+          physical_descriptions: [
+            {
+              extents: ['1 sound disc (20 min.)']
+            },
+            {
+              dimensions: ['1/4 in. tape', '10 x 27 cm', '7 1/4 x 3 1/2 in.']
+            }
+          ]
+        }
+      end
+
+      include_examples 'mapper', described_class
+    end
+
     context 'with a single extent and a single dimension' do
       let(:ttl) do
         <<~TTL


### PR DESCRIPTION
## Why was this change made?

FIxes #158  (Map bf:illustrativeContent to MARC 300b and to MARC 008/18)

There is some refactoring bundled in.

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?



