### PR TITLE
Remove null gacs.

### DIFF
--- a/lib/rdf2marc/rdf2model/mappers/number_and_code_fields.rb
+++ b/lib/rdf2marc/rdf2model/mappers/number_and_code_fields.rb
@@ -110,7 +110,7 @@ module Rdf2marc
             Resolver.resolve_geographic_area_code(gac_uri)
           end
           {
-            geographic_area_codes: gacs.sort
+            geographic_area_codes: gacs.compact.sort
           }
         end
 


### PR DESCRIPTION
## Why was this change made?
```
$ exe/rdf2marc https://api.stage.sinopia.io/resource/d034cef5-f8d8-428b-86ae-2295da5be6cc
W, [2022-01-20T09:53:43.774704 #49211]  WARN -- : Could not get GAC for http://id.loc.gov/authorities/subjects/sh85074879 since missing field 043.
Traceback (most recent call last):
	6: from exe/rdf2marc:16:in `<main>'
	5: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/converter.rb:13:in `convert'
	4: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/rdf2model.rb:8:in `to_model'
	3: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/rdf2model/mapper.rb:14:in `generate'
	2: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/rdf2model/mappers/number_and_code_fields.rb:14:in `generate'
	1: from /Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/rdf2model/mappers/number_and_code_fields.rb:113:in `geographic_area_codes'
/Users/jlittman/data/ld4p/rdf2marc/lib/rdf2marc/rdf2model/mappers/number_and_code_fields.rb:113:in `sort': comparison of String with nil failed (ArgumentError)
```


## How was this change tested?
Locally


## Which documentation and/or configurations were updated?



