### PR TITLE
Set other as default second indicator for 050.

### DIFF
--- a/lib/rdf2marc/models/number_and_code_field/lc_call_number.rb
+++ b/lib/rdf2marc/models/number_and_code_field/lc_call_number.rb
@@ -5,7 +5,7 @@ module Rdf2marc
     module NumberAndCodeField
       # Model for 050 - Library of Congress Call Number.
       class LcCallNumber < Struct
-        attribute :assigned_by, Types::String.default('lc').enum('lc', 'other')
+        attribute :assigned_by, Types::String.default('other').enum('lc', 'other')
         attribute? :classification_numbers, Types::Array.of(Types::String)
         attribute? :item_number, Types::String
       end


### PR DESCRIPTION
closes #171

## Why was this change made?
Per ticket.


## How was this change tested?



## Which documentation and/or configurations were updated?



