### PR TITLE
Displays term instead of calling value method for nodes

### DIFF
--- a/lib/rdf2marc/graph_query.rb
+++ b/lib/rdf2marc/graph_query.rb
@@ -80,7 +80,7 @@ module Rdf2marc
     def to_literal(term)
       return nil if term.nil?
 
-      raise MappingError, "Not a literal: #{term.value}" unless term.is_a?(RDF::Literal)
+      raise MappingError, "Not a literal: #{term}" unless term.is_a?(RDF::Literal)
 
       term.value
     end
@@ -88,7 +88,7 @@ module Rdf2marc
     def to_uri(term)
       return nil if term.nil?
 
-      raise MappingError, "Not a URI: #{term.value}" unless term.is_a?(RDF::URI)
+      raise MappingError, "Not a URI: #{term}" unless term.is_a?(RDF::URI)
 
       term.value
     end


### PR DESCRIPTION
## Why was this change made?
When investigating a conversion error, trying to raise the `MappingError` resulted in `NoMethodError` because a blank node does not have a `value` method. 

## How was this change tested?
unit tests

## Which documentation and/or configurations were updated?
n/a


