### PR TITLE
adjust build_lambda task ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ orbs:
   ruby: circleci/ruby@2.1.0
   aws-cli: circleci/aws-cli@2.0
 references:
+  # if you change the default ruby version, update the references in the "build_lambda" run task below
   default_ruby_version: &default_ruby_version "3.2"
   ruby_envs: &ruby_envs
     environment:
@@ -106,9 +107,9 @@ jobs:
           name: Build layer zip
           command: |
             mkdir -p tmp/ruby/gems
-            cp -r vendor/bundle/ruby/2.7.0 tmp/ruby/gems
+            cp -r vendor/bundle/ruby/3.2.0 tmp/ruby/gems
             cd tmp
-            zip -r layer.zip ruby/gems/2.7.0/
+            zip -r layer.zip ruby/gems/3.2.0/
             cd ..
             mv tmp/layer.zip .
       - run:


### PR DESCRIPTION
## Why was this change made?

This changed updated the default ruby version: https://github.com/LD4P/rdf2marc/pull/294/files, but we have a reference to the previous ruby version in the circle config, which appears to be causing that to fail (which is only run the main branch, so it doesn't block dependency update merging and appears to be missed):

## How was this change tested?

CI
