### PR TITLE
Update ruby vendor path for lamba build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,9 +107,9 @@ jobs:
           name: Build layer zip
           command: |
             mkdir -p tmp/ruby/gems
-            cp -r vendor/bundle/ruby/3.2.0 tmp/ruby/gems
+            cp -r vendor/bundle/ruby/3.3.0 tmp/ruby/gems
             cd tmp
-            zip -r layer.zip ruby/gems/3.2.0/
+            zip -r layer.zip ruby/gems/3.3.0/
             cd ..
             mv tmp/layer.zip .
       - run:


### PR DESCRIPTION
## Why was this change made?

Updated the version of ruby missed that the lambda build requires knowing the gem path.

## How was this change tested?



## Which documentation and/or configurations were updated?



